### PR TITLE
Create all parent directories for config file

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -359,6 +359,7 @@ pub fn write_config(config: Config, logger: &Logger) -> Result<(), AppError> {
   let config_path = fw_path()?;
   info!(logger, "Writing config"; "path" => format!("{:?}", config_path));
   config.check_sanity(logger).and_then(|c| {
+    std::fs::create_dir_all(config_path.parent().expect("Failed to get parent of config path"))?;
     let mut buffer = File::create(config_path)?;
     serde_json::ser::to_writer_pretty(&mut buffer, &c).map_err(AppError::BadJson)
   })


### PR DESCRIPTION
I wanted to make fw conform to the [XDG standard](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) by setting `export FW_CONFIG_PATH=$XDG_CONFIG_HOME/fw/config`. When doing this fw setup failed to write the config file because the folder fw/config did not exists in my ~/.config folder. fw should create any parent directories needed for the config file. Here is a quick fix. 