### PR TITLE
[fix] msys and mingw path correction

### DIFF
--- a/src/shell/setup.bash
+++ b/src/shell/setup.bash
@@ -318,7 +318,7 @@ __fw_complete()
 
     _fw_tag_add() {
         case "$cur" in
-            --*) __fw_comp "--after-clone --after-workon --override-path" ; return ;;
+            --*) __fw_comp "--after-clone --after-workon --workspace" ; return ;;
         esac
         __fw_comp "$(__fw_tags)"
     }

--- a/src/shell/workon-fzf.bash
+++ b/src/shell/workon-fzf.bash
@@ -1,13 +1,19 @@
 __workon()
 {
-  local PROJECT="$(fw -q ls | fzf --cycle --query=$1 --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse)"
-  local SCRIPT="$(fw -q gen-workon $2 $PROJECT)"
-  [ $? -eq 0 ] && eval "$SCRIPT" || printf "$SCRIPT\n"
+    local PROJECT="$(fw -q ls | fzf --cycle --query=$1 --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse)"
+    local SCRIPT="$(fw -q gen-workon $2 $PROJECT)"
+    case $(uname -s) in
+        MINGW*|MSYS*) SCRIPT="cd $(echo "/${SCRIPT:3}" | sed -e 's/\\/\//g' -e 's/://')" ;; 
+    esac
+    [ $? -eq 0 ] && eval "$SCRIPT" || printf "$SCRIPT\n"
 }
 
 reworkon()
 {
     local SCRIPT="$(fw -q gen-reworkon $@)"
+    case $(uname -s) in
+        MINGW*|MSYS*) SCRIPT="cd $(echo "/${SCRIPT:3}" | sed -e 's/\\/\//g' -e 's/://')" ;; 
+    esac
     [ $? -eq 0 ] && eval "$SCRIPT" || printf "$SCRIPT"
 }
 

--- a/src/shell/workon.bash
+++ b/src/shell/workon.bash
@@ -1,18 +1,27 @@
 workon()
 {
     local SCRIPT="$(fw -q gen-workon $@)"
+    case $(uname -s) in
+        MINGW*|MSYS*) SCRIPT="cd $(echo "/${SCRIPT:3}" | sed -e 's/\\/\//g' -e 's/://')" ;; 
+    esac
     [ $? -eq 0 ] && eval "$SCRIPT" || printf "$SCRIPT"
 }
 
 reworkon()
 {
     local SCRIPT="$(fw -q gen-reworkon $@)"
+    case $(uname -s) in
+        MINGW*|MSYS*) SCRIPT="cd $(echo "/${SCRIPT:3}" | sed -e 's/\\/\//g' -e 's/://')" ;; 
+    esac
     [ $? -eq 0 ] && eval "$SCRIPT" || printf "$SCRIPT"
 }
 
 reworkon()
 {
     local SCRIPT="$(fw -q gen-workon -x $@)"
+    case $(uname -s) in
+        MINGW*|MSYS*) SCRIPT="cd $(echo "/${SCRIPT:3}" | sed -e 's/\\/\//g' -e 's/://')" ;; 
+    esac
     [ $? -eq 0 ] && eval "$SCRIPT" || printf "$SCRIPT"
 }
 


### PR DESCRIPTION
In the setup scripts check to see if the current uname
is either msys or mingw. If so then conform the genreated
windows path from something like C:\Users\... to /C/Users/...
This make cd command pass on these environments