### PR TITLE
Indicate config location in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,7 +12,7 @@
    You can start working on any project quickly, even if it's not in your flat structured workspace (better than ~CDPATH~!).
    It also "sets up" your environment when you start working on a project (compile stuff, run ~make~, activate ~virtualenv~ or ~nvm~, fire up ~sbt~ shell, etc.)
 
-   [[doc/sample_config.json][Here's]] an example configuration that should be easy to grasp:
+   [[doc/sample_config.json][Here's]] an example configuration that should be easy to grasp. The default configuration location is =~/.fw.json=, and can be overridden by ~FW_CONFIG_PATH~.
 
    Per default projects are cloned into ~${settings.workspace}/${project.name}~ but you can override that by setting an ~override_path~ attribute as seen above.
 


### PR DESCRIPTION
I spent a few minutes trying to work out where to put the config file, and eventually went to the code to work it out. This might save the next person a bit of grief. 🙂