### PR TITLE
Don't use empty functions for bash

### DIFF
--- a/src/shell/setup.bash
+++ b/src/shell/setup.bash
@@ -259,6 +259,7 @@ __fw_complete()
         __fw_comp "$(__fw_projects)"
     }
     _fw_migrate() {
+        :
     }
 
     _fw_org_import () {


### PR DESCRIPTION
Apparently bash can't deal with empty functions…
for reference https://stackoverflow.com/questions/30998558/empty-function-in-bash