### PR TITLE
Fix workon generation for paths containing spaces

### DIFF
--- a/src/workon/mod.rs
+++ b/src/workon/mod.rs
@@ -54,7 +54,7 @@ pub fn gen(name: &str, maybe_config: Result<config::Config, AppError>, quick: bo
     Err(AppError::UserError(format!("project key {} found but path {} does not exist", name, path)))
   } else {
     let mut commands: Vec<String> = vec![];
-    commands.push(format!("cd {}", path));
+    commands.push(format!("cd '{}'", path));
     if !quick {
       commands.extend_from_slice(&config.resolve_after_workon(logger, project))
     }


### PR DESCRIPTION
With the current logic for generating workon scripts, a project named "my project" would create a workon script like

```sh
cd /fw-workspace/my project
```

This will cause the cd to fail. This patch fixes the issue by quoting the paths passed to `cd` in the workon script.