### PR TITLE
Filter archived projects from gitlab-import

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -105,7 +105,18 @@ For further information please have a look at our README https://github.com/broc
         )
         .arg(Arg::with_name("ORG_NAME").value_name("ORG_NAME").index(1).required(true)),
     )
-    .subcommand(SubCommand::with_name("gitlab-import").about("Import all owned repositories / your organizations repositories from gitlab into fw"))
+    .subcommand(
+      SubCommand::with_name("gitlab-import")
+        .about("Import all owned repositories / your organizations repositories from gitlab into fw")
+        .arg(
+          Arg::with_name("include-archived")
+            .help("Also import archived projects")
+            .long("include-archived")
+            .short("a")
+            .takes_value(false)
+            .required(false),
+        ),
+    )
     .subcommand(
       SubCommand::with_name("add-remote")
         .about("Add remote to project")

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -109,12 +109,14 @@ For further information please have a look at our README https://github.com/broc
       SubCommand::with_name("gitlab-import")
         .about("Import all owned repositories / your organizations repositories from gitlab into fw")
         .arg(
-          Arg::with_name("include-archived")
-            .help("Also import archived projects")
-            .long("include-archived")
+          Arg::with_name("include")
+            .help("Filter projects to import by state")
+            .long("include")
             .short("a")
-            .takes_value(false)
-            .required(false),
+            .takes_value(true)
+            .value_name("state")
+            .possible_values(&["active", "archived", "both"])
+            .default_value("active"),
         ),
     )
     .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,14 @@ fn _main() -> i32 {
       subcommand_matches.is_present("include-archived"),
       &subcommand_logger,
     ),
-    "gitlab-import" => setup::gitlab_import(config, subcommand_matches.is_present("include-archived"), &subcommand_logger),
+    "gitlab-import" => {
+      let state = subcommand_matches
+        .value_of("include")
+        .expect("argument required by clap.rs")
+        .parse()
+        .expect("argument values restricted by clap.rs");
+      setup::gitlab_import(config, state, &subcommand_logger)
+    }
     "gen-workon" => workon::gen(
       subcommand_matches.value_of("PROJECT_NAME").expect("argument required by clap.rs"),
       config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn _main() -> i32 {
       subcommand_matches.is_present("include-archived"),
       &subcommand_logger,
     ),
-    "gitlab-import" => setup::gitlab_import(config, &subcommand_logger),
+    "gitlab-import" => setup::gitlab_import(config, subcommand_matches.is_present("include-archived"), &subcommand_logger),
     "gen-workon" => workon::gen(
       subcommand_matches.value_of("PROJECT_NAME").expect("argument required by clap.rs"),
       config,

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -10,6 +10,26 @@ use std::fs;
 use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 
+#[derive(Copy, Clone)]
+pub enum ProjectState {
+  Active,
+  Archived,
+  Both,
+}
+
+impl std::str::FromStr for ProjectState {
+  type Err = AppError;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "active" => Ok(Self::Active),
+      "archived" => Ok(Self::Archived),
+      "both" => Ok(Self::Both),
+      _ => Err(AppError::InternalError("invalid value for ProjectState")), // TODO should this be unreachable?,
+    }
+  }
+}
+
 pub fn setup(workspace_dir: &str, logger: &Logger) -> Result<(), AppError> {
   let setup_logger = logger.new(o!("workspace" => workspace_dir.to_owned()));
   debug!(setup_logger, "Entering setup");
@@ -60,7 +80,7 @@ fn determine_projects(path: PathBuf, logger: &Logger) -> Result<BTreeMap<String,
   Ok(projects)
 }
 
-pub fn gitlab_import(maybe_config: Result<Config, AppError>, include_archived: bool, logger: &Logger) -> Result<(), AppError> {
+pub fn gitlab_import(maybe_config: Result<Config, AppError>, state: ProjectState, logger: &Logger) -> Result<(), AppError> {
   use gitlab::api::Query;
   let current_config = maybe_config?;
 
@@ -76,8 +96,14 @@ pub fn gitlab_import(maybe_config: Result<Config, AppError>, include_archived: b
 
   let mut builder = gitlab::api::projects::Projects::builder();
   builder.owned(true);
-  if !include_archived {
-    builder.archived(false);
+  match state {
+    ProjectState::Active => {
+      builder.archived(false);
+    }
+    ProjectState::Archived => {
+      builder.archived(true);
+    }
+    ProjectState::Both => {}
   }
 
   // owned repos and your organizations repositories


### PR DESCRIPTION
This commit changes the default behaviour of the `gitlab-import` subcommand to exclude archived projects from the import. The previous behaviour, which includes archived projects, can be enabled with the `--include-archived` flag.