### PR TITLE
add fzf support to fish-shell integration

### DIFF
--- a/doc/installation.org
+++ b/doc/installation.org
@@ -38,6 +38,17 @@
     fi
     #+END_SRC
 
+  Fish
+    #+BEGIN_SRC shell-script
+    if test -x (command -v fw)
+      if test -x (command -v fzf)
+        fw print-fish-setup -f | source
+      else
+        fw print-fish-setup | source
+      end
+    end
+    #+END_SRC
+
 
 ** Without fzf
    If you don't want ~fzf~ integration:

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -74,7 +74,11 @@ For further information please have a look at our README https://github.com/broc
         .about("Prints bash completion code.")
         .arg(Arg::with_name("with-fzf").long("with-fzf").short("-f").help("Integrate with fzf")),
     )
-    .subcommand(SubCommand::with_name("print-fish-setup").about("Prints fish completion code."))
+    .subcommand(
+      SubCommand::with_name("print-fish-setup")
+        .about("Prints fish completion code.")
+        .arg(Arg::with_name("with-fzf").long("with-fzf").short("-f").help("Integrate with fzf")),
+    )
     .subcommand(
       SubCommand::with_name("setup")
         .about("Setup config from existing workspace")

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn _main() -> i32 {
     ),
     "print-zsh-setup" => crate::shell::print_zsh_setup(subcommand_matches.is_present("with-fzf")),
     "print-bash-setup" => crate::shell::print_bash_setup(subcommand_matches.is_present("with-fzf")),
-    "print-fish-setup" => crate::shell::print_fish_setup(),
+    "print-fish-setup" => crate::shell::print_fish_setup(subcommand_matches.is_present("with-fzf")),
     "tag" => {
       let subsubcommand_name: String = subcommand_matches.subcommand_name().expect("subcommand matches enforced by clap.rs").to_owned();
       let subsubcommand_matches: clap::ArgMatches = subcommand_matches

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -28,10 +28,17 @@ pub fn print_bash_setup(use_fzf: bool) -> Result<(), AppError> {
   Ok(())
 }
 
-pub fn print_fish_setup() -> Result<(), AppError> {
+pub fn print_fish_setup(use_fzf: bool) -> Result<(), AppError> {
   let setup = include_str!("setup.fish");
+  let basic = include_str!("workon.fish");
+  let fzf = include_str!("workon-fzf.fish");
 
   println!("{}", setup);
+  if use_fzf {
+    println!("{}", fzf);
+  } else {
+    println!("{}", basic);
+  }
 
   Ok(())
 }

--- a/src/shell/setup.fish
+++ b/src/shell/setup.fish
@@ -1,173 +1,145 @@
-if command -v fw >/dev/null 2>&1
-  function __fw_projects
-    fw -q ls
-  end
-
-  function __fw_tags
-    fw -q tag ls
-  end
-
-  function __fw_subcommands
-    set -l __fw_subcommands_in_zsh_format \
-      'sync:Sync workspace' \
-      'setup:Setup config from existing workspace' \
-      'import:Import existing git folder to fw' \
-      'add:Add project to workspace' \
-      'add-remote:Add remote to project' \
-      'remove-remote:Removes remote from project' \
-      'remove:Remove project from workspace' \
-      'foreach:Run script on each project' \
-      'projectile:Create projectile bookmarks' \
-      'ls:List projects' \
-      'inspect:Inspect project' \
-      'update:Update project settings' \
-      'tag:Manipulate tags' \
-      'print-path:Print project path to stdout' \
-      'org-import:Import all repositories from a github org' \
-      'gitlab-import:Import all owned repositories / your organizations repositories from gitlab'
-
-    for subcmd in $__fw_subcommands_in_zsh_format
-      echo (string replace -r ':' '\t' $subcmd)
-    end
-  end
-
-  function __fw_tag_subcommands
-    set -l __fw_tag_subcommands_in_zsh_format \
-      'add:Adds a tag' \
-      'rm:Removes a tag' \
-      'ls:Lists tags' \
-      'inspect:inspect a tag' \
-      'tag-project:Add a tag to a project' \
-      'untag-project:Remove a tag from a project' \
-      'autotag:Execute command for every tagged project'
-
-    for subcmd in $__fw_tag_subcommands_in_zsh_format
-      echo (string replace -r ':' '\t' $subcmd)
-    end
-  end
-
-  function __fish_fw_is_arg_n -d 'Indicates if completion is for the nth argument (ignoring options)'
-    set -l args (__fish_print_cmd_args_without_options)
-
-    test (count $args) -eq $argv[1]
-  end
-
-  function __fish_fw_needs_command
-    __fish_fw_is_arg_n 1
-  end
-
-  function __fish_fw_command_in
-    set -l args (__fish_print_cmd_args_without_options)
-
-    contains -- $args[2] $argv
-  end
-
-  function __fish_fw_subcommand_in
-    set -l args (__fish_print_cmd_args_without_options)
-
-    contains -- $args[3] $argv
-  end
-
-  function __fish_fw_completion_for_command
-    __fish_fw_is_arg_n 2; and __fish_fw_command_in $argv[1]
-  end
-
-  function __fish_fw_completion_for_command_subcommand
-    __fish_fw_is_arg_n 3; and __fish_fw_command_in $argv[1]; and __fish_fw_subcommand_in $argv[2]
-  end
-
-  function __fish_fw_needs_project_arg
-    if __fish_fw_is_arg_n 2
-      __fish_fw_command_in add-remote remove-remote print-path inspect update remove
-    else if __fish_fw_is_arg_n 3 and __fish_fw_command_in tag
-      __fish_fw_subcommand_in ls tag-project untag-project
-    else
-      return 1
-    end
-  end
-
-  function __fish_fw_needs_tag_arg
-    if ! __fish_fw_command_in tag
-      return 1
-    end
-
-    if __fish_fw_is_arg_n 3
-      __fish_fw_subcommand_in inspect rm
-    else if __fish_fw_is_arg_n 4
-      __fish_fw_subcommand_in tag-project untag-project
-    else
-      return 1
-    end
-  end
-
-  complete -ec fw
-
-  complete -c fw -n '__fish_fw_needs_command' -f -xa '(__fw_subcommands)'
-  complete -c fw -n '__fish_fw_command_in tag; and __fish_fw_is_arg_n 2' -f -xa '(__fw_tag_subcommands)'
-  complete -c fw -n '__fish_fw_needs_project_arg' -f -xa '(__fw_projects)'
-  complete -c fw -n '__fish_fw_needs_tag_arg' -f -xa '(__fw_tags)'
-
-  complete -c fw -n '__fish_fw_is_arg_n 1' -s V -l version -d 'Print version information'
-  complete -c fw -n '__fish_fw_is_arg_n 1' -s h -l help    -d 'Print help information'
-  complete -c fw -n '__fish_fw_is_arg_n 1' -s q            -d 'Make fw quiet'
-  complete -c fw -n '__fish_fw_is_arg_n 1' -s v            -d 'Set the level of verbosity'
-
-  complete -c fw -n 'not __fish_fw_is_arg_n 1' -l help -s h -d 'Print help information for subcommand'
-
-  complete -c fw -n '__fish_fw_completion_for_command sync'      -l no-ff-merge \
-    -d 'No fast forward merge'
-  complete -c fw -n '__fish_fw_completion_for_command sync' -s q -l no-progress-bar
-  complete -c fw -n '__fish_fw_completion_for_command sync' -s n -l only-new \
-    -d 'Only clones projects, skips all actions for projects already on your machine.'
-  complete -c fw -n '__fish_fw_completion_for_command sync' -s p -l parallelism \
-    -d 'Set the number of threads'
-
-  complete -c fw -n '__fish_fw_completion_for_command org-import' -s a -l include-archived
-
-  complete -c fw -n '__fish_fw_completion_for_command foreach' -s p \
-    -d 'Set the number of threads'
-  complete -c fw -n '__fish_fw_completion_for_command foreach' -s t -l tag \
-    -d 'Filter projects by tag. More than 1 is allowed.'
-
-  complete -c fw -n '__fish_fw_completion_for_command ls' -s t -l tag \
-    -d 'Filter projects by tag. More than 1 is allowed.'
-
-  complete -c fw -n '__fish_fw_completion_for_command update' -l after-clone
-  complete -c fw -n '__fish_fw_completion_for_command update' -l after-workon
-  complete -c fw -n '__fish_fw_completion_for_command update' -l git-url
-  complete -c fw -n '__fish_fw_completion_for_command update' -l override-path
-
-  complete -c fw -n '__fish_fw_completion_for_command_subcommand tag add' -l after-clone
-  complete -c fw -n '__fish_fw_completion_for_command_subcommand tag add' -l after-workon
-  complete -c fw -n '__fish_fw_completion_for_command_subcommand tag add' -l git-url
-  complete -c fw -n '__fish_fw_completion_for_command_subcommand tag add' -l override-path
-
-  complete -c fw -n '__fish_fw_completion_for_command_subcommand tag autotag' -s p \
-    -d 'Set the number of threads'
-
-  function __fish_fw_use_script
-    if test $argv[1] -eq 0
-      echo $argv[2] | source
-    else
-      printf "$argv[2]\n"
-    end
-  end
-
-  function workon
-    set -l script (fw -q gen-workon $argv)
-    __fish_fw_use_script $status $script
-  end
-
-  function nworkon
-    set -l script (fw -q gen-workon -x $argv)
-    __fish_fw_use_script $status $script
-  end
-
-  function reworkon
-    set -l script (fw -q gen-reworkon $argv)
-    __fish_fw_use_script $status $script
-  end
-
-  complete -c workon -f -xa "(__fw_projects)"
-  complete -c nworkon -f -xa "(__fw_projects)"
+function __fw_projects
+  fw -q ls
 end
+
+function __fw_tags
+  fw -q tag ls
+end
+
+function __fw_subcommands
+  set -l __fw_subcommands_in_zsh_format \
+    'sync:Sync workspace' \
+    'setup:Setup config from existing workspace' \
+    'import:Import existing git folder to fw' \
+    'add:Add project to workspace' \
+    'add-remote:Add remote to project' \
+    'remove-remote:Removes remote from project' \
+    'remove:Remove project from workspace' \
+    'foreach:Run script on each project' \
+    'projectile:Create projectile bookmarks' \
+    'ls:List projects' \
+    'inspect:Inspect project' \
+    'update:Update project settings' \
+    'tag:Manipulate tags' \
+    'print-path:Print project path to stdout' \
+    'org-import:Import all repositories from a github org' \
+    'gitlab-import:Import all owned repositories / your organizations repositories from gitlab'
+
+  for subcmd in $__fw_subcommands_in_zsh_format
+    echo (string replace -r ':' '\t' $subcmd)
+  end
+end
+
+function __fw_tag_subcommands
+  set -l __fw_tag_subcommands_in_zsh_format \
+    'add:Adds a tag' \
+    'rm:Removes a tag' \
+    'ls:Lists tags' \
+    'inspect:inspect a tag' \
+    'tag-project:Add a tag to a project' \
+    'untag-project:Remove a tag from a project' \
+    'autotag:Execute command for every tagged project'
+
+  for subcmd in $__fw_tag_subcommands_in_zsh_format
+    echo (string replace -r ':' '\t' $subcmd)
+  end
+end
+
+function __fish_fw_is_arg_n -d 'Indicates if completion is for the nth argument (ignoring options)'
+  set -l args (__fish_print_cmd_args_without_options)
+
+  test (count $args) -eq $argv[1]
+end
+
+function __fish_fw_needs_command
+  __fish_fw_is_arg_n 1
+end
+
+function __fish_fw_command_in
+  set -l args (__fish_print_cmd_args_without_options)
+
+  contains -- $args[2] $argv
+end
+
+function __fish_fw_subcommand_in
+  set -l args (__fish_print_cmd_args_without_options)
+
+  contains -- $args[3] $argv
+end
+
+function __fish_fw_completion_for_command
+  __fish_fw_is_arg_n 2; and __fish_fw_command_in $argv[1]
+end
+
+function __fish_fw_completion_for_command_subcommand
+  __fish_fw_is_arg_n 3; and __fish_fw_command_in $argv[1]; and __fish_fw_subcommand_in $argv[2]
+end
+
+function __fish_fw_needs_project_arg
+  if __fish_fw_is_arg_n 2
+    __fish_fw_command_in add-remote remove-remote print-path inspect update remove
+  else if __fish_fw_is_arg_n 3 and __fish_fw_command_in tag
+    __fish_fw_subcommand_in ls tag-project untag-project
+  else
+    return 1
+  end
+end
+
+function __fish_fw_needs_tag_arg
+  if ! __fish_fw_command_in tag
+    return 1
+  end
+
+  if __fish_fw_is_arg_n 3
+    __fish_fw_subcommand_in inspect rm
+  else if __fish_fw_is_arg_n 4
+    __fish_fw_subcommand_in tag-project untag-project
+  else
+    return 1
+  end
+end
+
+complete -ec fw
+
+complete -c fw -n '__fish_fw_needs_command' -f -xa '(__fw_subcommands)'
+complete -c fw -n '__fish_fw_command_in tag; and __fish_fw_is_arg_n 2' -f -xa '(__fw_tag_subcommands)'
+complete -c fw -n '__fish_fw_needs_project_arg' -f -xa '(__fw_projects)'
+complete -c fw -n '__fish_fw_needs_tag_arg' -f -xa '(__fw_tags)'
+
+complete -c fw -n '__fish_fw_is_arg_n 1' -s V -l version -d 'Print version information'
+complete -c fw -n '__fish_fw_is_arg_n 1' -s h -l help    -d 'Print help information'
+complete -c fw -n '__fish_fw_is_arg_n 1' -s q            -d 'Make fw quiet'
+complete -c fw -n '__fish_fw_is_arg_n 1' -s v            -d 'Set the level of verbosity'
+
+complete -c fw -n 'not __fish_fw_is_arg_n 1' -l help -s h -d 'Print help information for subcommand'
+
+complete -c fw -n '__fish_fw_completion_for_command sync'      -l no-ff-merge \
+  -d 'No fast forward merge'
+complete -c fw -n '__fish_fw_completion_for_command sync' -s q -l no-progress-bar
+complete -c fw -n '__fish_fw_completion_for_command sync' -s n -l only-new \
+  -d 'Only clones projects, skips all actions for projects already on your machine.'
+complete -c fw -n '__fish_fw_completion_for_command sync' -s p -l parallelism \
+  -d 'Set the number of threads'
+
+complete -c fw -n '__fish_fw_completion_for_command org-import' -s a -l include-archived
+
+complete -c fw -n '__fish_fw_completion_for_command foreach' -s p \
+  -d 'Set the number of threads'
+complete -c fw -n '__fish_fw_completion_for_command foreach' -s t -l tag \
+  -d 'Filter projects by tag. More than 1 is allowed.'
+
+complete -c fw -n '__fish_fw_completion_for_command ls' -s t -l tag \
+  -d 'Filter projects by tag. More than 1 is allowed.'
+
+complete -c fw -n '__fish_fw_completion_for_command update' -l after-clone
+complete -c fw -n '__fish_fw_completion_for_command update' -l after-workon
+complete -c fw -n '__fish_fw_completion_for_command update' -l git-url
+complete -c fw -n '__fish_fw_completion_for_command update' -l override-path
+
+complete -c fw -n '__fish_fw_completion_for_command_subcommand tag add' -l after-clone
+complete -c fw -n '__fish_fw_completion_for_command_subcommand tag add' -l after-workon
+complete -c fw -n '__fish_fw_completion_for_command_subcommand tag add' -l git-url
+complete -c fw -n '__fish_fw_completion_for_command_subcommand tag add' -l override-path
+
+complete -c fw -n '__fish_fw_completion_for_command_subcommand tag autotag' -s p \
+  -d 'Set the number of threads'

--- a/src/shell/workon-fzf.fish
+++ b/src/shell/workon-fzf.fish
@@ -1,0 +1,29 @@
+function __fish_fw_use_script
+  if test $argv[1] -eq 0
+    echo $argv[2] | source
+  else
+    printf "$argv[2]\n"
+  end
+end
+
+function __workon
+  set -l project (fw -q ls | fzf --cycle --query=$argv[1] --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse)
+  set -l script (fw -q gen-workon $argv[2] $project)
+  __fish_fw_use_script $status $script
+end
+
+function workon
+  __workon $argv[1]
+end
+
+function nworkon
+  __workon $argv[1] -x
+end
+
+function reworkon
+  set -l script (fw -q gen-reworkon $argv)
+  __fish_fw_use_script $status $script
+end
+
+complete -c workon -f -xa "(__fw_projects)"
+complete -c nworkon -f -xa "(__fw_projects)"

--- a/src/shell/workon.fish
+++ b/src/shell/workon.fish
@@ -1,0 +1,25 @@
+function __fish_fw_use_script
+  if test $argv[1] -eq 0
+    echo $argv[2] | source
+  else
+    printf "$argv[2]\n"
+  end
+end
+
+function workon
+  set -l script (fw -q gen-workon $argv)
+  __fish_fw_use_script $status $script
+end
+
+function nworkon
+  set -l script (fw -q gen-workon -x $argv)
+  __fish_fw_use_script $status $script
+end
+
+function reworkon
+  set -l script (fw -q gen-reworkon $argv)
+  __fish_fw_use_script $status $script
+end
+
+complete -c workon -f -xa "(__fw_projects)"
+complete -c nworkon -f -xa "(__fw_projects)"


### PR DESCRIPTION
Closes #107.

### Notes

- Added doc section corresponding to this feature
- Added command line option to support it
- Removed conditional wrapper in `src/shell/setup.fish` since the recommended installation method includes the check for `fw` being accessible on the `$PATH` (not to mention the fact that the setup code is accessed by running the binary in the first place).