### PR TITLE
Reduce crate size in crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/brocode/fw"
 readme = "README.org"
 keywords = ["workspace", "productivity", "cli", "automation", "developer-tools" ]
 edition = "2018"
+include = ["src/**/*", "LICENSE", "README.org"]
 
 [dependencies]
 walkdir = "2"


### PR DESCRIPTION
|  File  | Size (Byte) |
|--------|--------|
| clippy.toml                                   |          34  |
| rustfmt.toml                                   |          79 |
| .gitmodules                                    |         110 |
| .editorconfig                                  |         119 |
| .github/dependabot.yml                         |         147 |
| doc/example_config/tags/default/fkbr           |         212 |
| doc/example_config/tags/default/js             |         223 |
| doc/example_config/tags/default/python         |         228 |
| doc/example_config/tags/github/brocode/brocode |         235 |
| doc/example_config/tags/default/brogo          |         243 |
| doc/example_config/tags/default/git            |         265 |
| doc/example_config/tags/default/rust           |         276 |
| .gitignore                                     |         361 |
| doc/example_config/projects/default/docker     |         413 |
| doc/example_config/projects/default/fw         |         423 |
| doc/example_config/settings.toml               |         442 |
| doc/example_config/projects/default/pybuilder  |         492 |
| package.sh                                     |         741 |
| appveyor.yml                                   |         930 |
| logo/fw_rgb.svg                                |        1520 |
| .travis.yml                                    |        1750 |
| doc/installation.org                           |        2609 |
| doc/usage.org                                  |        3476 |
| logo/fw_rgb.png                                |        6408 |
| logo/fw_rgb.eps                                |     1014010 |
| logo/fw_cmyk.eps                               |     1898082 |


Saved 96% or 2.9 MB in 26 files (of 3.1 MB and 57 files in entire crate)