### PR TITLE
Use select-1 for fzf in workon scripts

### DIFF
--- a/src/shell/workon-fzf.bash
+++ b/src/shell/workon-fzf.bash
@@ -1,6 +1,6 @@
 __workon()
 {
-    local PROJECT="$(fw -q ls | fzf --cycle --query=$1 --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse)"
+    local PROJECT="$(fw -q ls | fzf --cycle --query=$1 --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse --select-1)"
     local SCRIPT="$(fw -q gen-workon $2 $PROJECT)"
     case $(uname -s) in
         MINGW*|MSYS*) SCRIPT="cd $(echo "/${SCRIPT:3}" | sed -e 's/\\/\//g' -e 's/://')" ;; 

--- a/src/shell/workon-fzf.fish
+++ b/src/shell/workon-fzf.fish
@@ -7,7 +7,7 @@ function __fish_fw_use_script
 end
 
 function __workon
-  set -l project (fw -q ls | fzf --cycle --query=$argv[1] --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse)
+  set -l project (fw -q ls | fzf --cycle --query=$argv[1] --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse --select-1)
   set -l script (fw -q gen-workon $argv[2] $project)
   __fish_fw_use_script $status $script
 end

--- a/src/shell/workon-fzf.zsh
+++ b/src/shell/workon-fzf.zsh
@@ -1,5 +1,5 @@
 __workon () {
-  PROJECT="$(fw -q ls | fzf --cycle --query=$1 --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse)"
+  PROJECT="$(fw -q ls | fzf --cycle --query=$1 --color=light --preview-window=top:50% --preview='fw -q inspect {}' --no-mouse --select-1)"
   SCRIPT="$(fw -q gen-workon $2 $PROJECT)";
   if [ $? -eq 0 ]; then
     eval "$SCRIPT";


### PR DESCRIPTION
fzf's select-1 argument automatically selects a single match in project names.

This can be helpful if the search phrase exactly matches the name of the project.
