### PR TITLE
upgrade to git2 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,9 +594,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "94781080dd1a6b55dea7c46540d5bac87742a22f6dc2d84e54a5071ad6f0e387"
 dependencies = [
  "bitflags",
  "libc",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.0+1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "864e22fc06cae62860398cd854c93d5867f11c02ec916aa1417b440f170df23a"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ toml = "0.5"
 slog-async = "2"
 serde_json = "1.0.3"
 serde = {version = "1", features = ["derive"] }
-git2 = "0.13"
+git2 = "0.14"
 maplit = "1.0"
 rayon = "1"
 regex = "1"


### PR DESCRIPTION
This upgrade is necessary, as fw currently segfaults with libgit2 >= 1.4.0 installed on the system.

See rust-lang/git2-rs#813