### PR TITLE
Show faulty config file on error

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -41,10 +41,10 @@ pub fn read_config(logger: &Logger) -> Result<Config, AppError> {
       if project_file.metadata()?.is_file() && !project_file.file_name().to_os_string().eq(".DS_Store") {
         let raw_project = read_to_string(project_file.path())?;
         let mut project: Project = match toml::from_str(&raw_project) {
-          Ok(x) => Ok(x),
-          Err(e) => {
+          o @ Ok(_) => o,
+          e @ Err(_) => {
             eprintln!("There is an issue in your config for project {}", project_file.file_name().to_string_lossy());
-            Err(e)
+            e
           }
         }?;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,7 +40,14 @@ pub fn read_config(logger: &Logger) -> Result<Config, AppError> {
       let project_file = maybe_project_file?;
       if project_file.metadata()?.is_file() && !project_file.file_name().to_os_string().eq(".DS_Store") {
         let raw_project = read_to_string(project_file.path())?;
-        let mut project: Project = toml::from_str(&raw_project)?;
+        let mut project: Project = match toml::from_str(&raw_project) {
+          Ok(x) => Ok(x),
+          Err(e) => {
+            eprintln!("There is an issue in your config for project {}", project_file.file_name().to_string_lossy());
+            Err(e)
+          },
+        }?;
+
         project.name = project_file
           .file_name()
           .to_str()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,7 +45,7 @@ pub fn read_config(logger: &Logger) -> Result<Config, AppError> {
           Err(e) => {
             eprintln!("There is an issue in your config for project {}", project_file.file_name().to_string_lossy());
             Err(e)
-          },
+          }
         }?;
 
         project.name = project_file

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,7 +38,7 @@ pub fn read_config(logger: &Logger) -> Result<Config, AppError> {
   if paths.projects.exists() {
     for maybe_project_file in WalkDir::new(&paths.projects).follow_links(true) {
       let project_file = maybe_project_file?;
-      if project_file.metadata()?.is_file() {
+      if project_file.metadata()?.is_file() && !project_file.file_name().to_os_string().eq(".DS_Store") {
         let raw_project = read_to_string(project_file.path())?;
         let mut project: Project = toml::from_str(&raw_project)?;
         project.name = project_file
@@ -67,7 +67,8 @@ pub fn read_config(logger: &Logger) -> Result<Config, AppError> {
   if paths.tags.exists() {
     for maybe_tag_file in WalkDir::new(&paths.tags).follow_links(true) {
       let tag_file = maybe_tag_file?;
-      if tag_file.metadata()?.is_file() {
+
+      if tag_file.metadata()?.is_file() && !tag_file.file_name().to_os_string().eq(".DS_Store") {
         let raw_tag = read_to_string(tag_file.path())?;
         let mut tag: Tag = toml::from_str(&raw_tag)?;
         let tag_name: String = tag_file


### PR DESCRIPTION
This PR complements #228.

If your config is corrupted, there is currently no way to know WHICH project file is faulty.
It can be tested simply by adding a tag and omitting the closing quote:
```
# -*- mode: Conf; -*-
git = 'git@github.com:chevdor/foobar.git'
after_workon = ''
tags = [
    'rust',
    'shell                             <<<< ERROR HERE
]
```

This PR outputs a mesage to stderr mentioning which project does not deserialize properly:
```
     ... 
     Running `target/debug/fw ls`
There is an issue in your config for project foobar
Aug 17 15:14:12.533 WARN Could not read v2.0 config: Err(TomlDeError(Error { inner: ErrorInner { kind: NewlineInString, line: Some(9), col: 10, at: Some(199), message: "", key: [] } })). If you are running the setup right now this is expected., module: fw:22
Aug 17 15:14:12.533 CRIT Error running command, error: TomlDeError(Error { inner: ErrorInner { kind: NewlineInString, line: Some(9), col: 10, at: Some(199), message: "", key: [] } }), command: ls, module: fw:172
```
